### PR TITLE
Adds support for virtual resources.

### DIFF
--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -27,7 +27,7 @@ module.exports = function ( grunt ) {
                 // Warn on and remove invalid source files (if nonull was set).
                 if ( !grunt.file.exists( filepath ) ) {
                     grunt.log.warn( 'Source file ' + chalk.cyan( filepath ) + ' not found.' );
-                    return false;
+                    return false || f.nonull;
                 } else {
                     return true;
                 }


### PR DESCRIPTION
I ran into an issue when trying to run uncss on an MS MVC project. I was trying to uncss resources that did not actually exist on disk.

My grunt options looked like:

```js
uncss: {
    dist: {
        options: {
            urls: "http://localhost:54404"
        },
        files: [{
            dest: "./client-scripts/styles/login-min.css", 
            src: "Account/Login"
        }]
    }
}
```
The error I was getting was:

```
Destination (./client-scripts/styles/login-min.css) not written because src files were empty.
```

I figured this wasn't an uncss issue as running the following worked perfectly fine:

```
> uncss http://localhost:54404/account/login > login-min.css
```

Digging into the source, I saw that files.src wasn't being stripped as it doesn't exist. Did some more digging and it seems like this is exactly what the `nonull` option is mean for. So changing the options to:

```js
uncss: {
    dist: {
        options: {
            urls: "http://localhost:54404"
        },
        files: [{
            dest: "./client-scripts/styles/login-min.css", 
            src: "Account/Login",
            nonull: true
        }]
    }
}
``` 

yielded:

```
>> Source file "http://localhost:54404/Account/Login" not found.
```

Unless I'm missing the point (which is entirely likely), the `nonull` option is specifically for when files can't be found. This patch still warns when a file isn't found, but still attempts to process the file when `nonull` is true.

I also think this fix will solve issue #66.