### PR TITLE
fail when no files and urls are defined

### DIFF
--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -33,7 +33,7 @@ module.exports = function ( grunt ) {
                 }
             });
 
-            if ( src.length === 0 ) {
+            if ( src.length === 0 && f.orig.src.length === 0 ) {
                 grunt.fail.warn( 'Destination (' + f.dest + ') not written because src files were empty.' );
             }
 


### PR DESCRIPTION
If I use urls instead files, I got fail warning. Should be fixed with checking urls too.
