### PR TITLE
fix url bug

### DIFF
--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -33,16 +33,16 @@ module.exports = function ( grunt ) {
                 }
             });
 
-            if ( src.length === 0 && f.orig.src.length === 0 ) {
-                grunt.fail.warn( 'Destination (' + f.dest + ') not written because src files were empty.' );
-            }
-
             f.orig.src.forEach(function (source) {
                 if (/^https?/.test(source)) {
                     src.push(source);
                     options.urls.push(source);
                 }
             });
+
+            if ( src.length === 0 ) {
+                grunt.fail.warn( 'Destination (' + f.dest + ') not written because src files were empty.' );
+            }
 
             try {
                 uncss( src, options, function ( error, output, report ) {


### PR DESCRIPTION
When I specify src as url like this:

```js
files: {
  'test.css': 
    ['http://xxx/xx']
}
```

I got following exception:

**Warning: Destination (test.css) not written because src files were empty.**

I think in uncss.js:

```js
if ( src.length === 0 ) {
    grunt.fail.warn( 'Destination (' + f.dest + ') not written because src files were empty.' );
}

f.orig.src.forEach(function (source) {
    if (/^https?/.test(source)) {
        src.push(source);
        options.urls.push(source);
    }
});
```
It should be:

```js
f.orig.src.forEach(function (source) {
    if (/^https?/.test(source)) {
        src.push(source);
        options.urls.push(source);
    }
});
if ( src.length === 0 ) {
    grunt.fail.warn( 'Destination (' + f.dest + ') not written because src files were empty.' );
}
```