### PR TITLE
Remove note about 0.8.1 lock in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,6 @@ a URL array that contains all the URLs on your website, and process all used sel
 [@lgladdy](https://github.com/lgladdy) wrote a guide on how to do this
 [on his blog](http://www.gladdy.co.uk/blog/2014/04/13/using-uncss-and-grunt-uncss-with-wordpress/)
 
-## Notes
-
-At present we have decided to lock grunt-uncss into [UnCSS 0.8.1](https://github.com/giakki/uncss/). This is the most recent version we consider stable for production use. We will be reviewing future UnCSS releases and deciding to upgrade when we feel sufficient stability is back.
-
 ## Yeoman Generator
 
 If you're looking for a webapp starting point with grunt-uncss integrated, see [generator-webapp-uncss](https://github.com/addyosmani/generator-webapp-uncss).


### PR DESCRIPTION
As per 17023aea910f413f42e6e9c05b1fc7e0cdb52463, UnCSS is no longer locked to 0.8.1