### PR TITLE
Fix issue #141 Object has no method 'forEach'

### DIFF
--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -33,11 +33,11 @@ module.exports = function ( grunt ) {
                 }
             });
 
-            if ( src.length === 0 && file.orig.src.length === 0 ) {
+            if ( src.length === 0 && file.src.length === 0 ) {
                 grunt.fail.warn( 'Destination (' + file.dest + ') not written because src files were empty.' );
             }
 
-            file.orig.src.forEach(function (source) {
+            file.src.forEach(function (source) {
                 if (/^https?/.test(source)) {
                     src.push(source);
                     options.urls.push(source);


### PR DESCRIPTION
I keep getting this error when I install grunt-uncss on a new development computer or server instance.
There I created a commit with the patch proposed by @jtwalters 

Hopefully this is useful to others.