### PR TITLE
Multiple files handled sequentially

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,6 +46,15 @@ module.exports = function(grunt) {
           report: 'gzip'
         }
       },
+      testMany: {
+        files: {
+          'tests/output.css': 'tests/index.html',
+          'tests/output2.css': 'tests/index2.html',
+        },
+        options: {
+          report: 'gzip'
+        }
+      },
       testUncssrc: {
         files: {
           'tests/output.css': 'tests/index.html'
@@ -125,6 +134,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', [
     'jshint',
     'uncss:test',
+    'uncss:testMany',
     'uncss:testUncssrc',
     'simplemocha'
   ]);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "async": "^1.5.0",
     "chalk": "~1.1.0",
     "maxmin": "~1.1.0",
     "uncss": "~0.12.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "~1.5.0",
     "chalk": "~1.1.0",
     "maxmin": "~1.1.0",
     "uncss": "~0.12.1"

--- a/tasks/uncss.js
+++ b/tasks/uncss.js
@@ -9,7 +9,8 @@
 'use strict';
 var uncss  = require( 'uncss' ),
     chalk  = require( 'chalk' ),
-    maxmin = require( 'maxmin' );
+    maxmin = require( 'maxmin' ),
+    async = require( 'async' );
 
 module.exports = function ( grunt ) {
     grunt.registerMultiTask( 'uncss', 'Remove unused CSS', function () {
@@ -21,7 +22,7 @@ module.exports = function ( grunt ) {
 
         options.urls = options.urls || [];
 
-        this.files.forEach(function ( file ) {
+        function processFile ( file, done ) {
 
             var src = file.src.filter(function ( filepath ) {
                 // Warn on and remove invalid source files (if nonull was set).
@@ -67,7 +68,15 @@ module.exports = function ( grunt ) {
                 grunt.fail.warn( err );
             }
 
-        });
+        }
+        
+        if (this.files.length === 1) {
+            processFile( this.files[0], done );
+        } else {
+            // Processing multiple files must be done sequentially
+            // until https://github.com/giakki/uncss/issues/136 is resolved.
+            async.eachSeries( this.files, processFile, done );
+        }
 
     });
 

--- a/tests/index2.html
+++ b/tests/index2.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Red vs. Blue</title>
+        <link rel="stylesheet" href="fixtures/adjacent.css">
+        <link rel="stylesheet" href="fixtures/child.css">
+        <link rel="stylesheet" href="fixtures/classes.css">
+        <link rel="stylesheet" href="fixtures/elements.css">
+    </head>
+    <body>
+        <div id="battleground">
+            <h1><span class="blue">Blue</span></h1>
+        </div>
+    </body>
+</html>

--- a/tests/output2.css
+++ b/tests/output2.css
@@ -1,0 +1,27 @@
+/*** uncss> filename: tests/fixtures/adjacent.css ***/
+
+/*** uncss> filename: tests/fixtures/child.css ***/
+
+h1 > span {
+  color: crimson;
+}
+
+/*** uncss> filename: tests/fixtures/classes.css ***/
+
+.blue {
+  color: blue;
+}
+
+/*** uncss> filename: tests/fixtures/elements.css ***/
+
+body {
+  font-size: 100%;
+}
+
+h1 {
+  font-size: 2rem;
+}
+
+span {
+  display: block;
+}


### PR DESCRIPTION
A workaround for #171: when there are several files to process, they are handled in sequence with `async.eachSeries` to avoid clashes between different instances of PhantomJS.