### PR TITLE
Fix broken test.

### DIFF
--- a/tests/selectors.js
+++ b/tests/selectors.js
@@ -53,13 +53,19 @@ describe( 'uncss', function () {
         expect( rawcss ).to.have.length.above( 0 );
     });
 
-    it( 'should read .uncssrc files', function () {
+    it( 'should read .uncssrc files', function ( done ) {
         uncss( readFile('index.html'), {
+            csspath: 'tests',
+            report: true,
             uncssrc: path.normalize('tests/.uncssrc')
         }, function ( err, res, report ) {
+            if ( err ) {
+                return done( err );
+            }
             expect( err ).to.equal( null );
             expect( res ).to.equal( rawcss );
             expect( report.original ).not.to.equal( null );
+            done();
         } );
     });
 


### PR DESCRIPTION
I am not sure why this test ever worked - I'm assuming this breaks now due to jsdom being less forgiving than PhantomJS.

Changes:
- Test is asynchronous,
- `report` flag must be true,
- `csspath` must be defined since input is raw html (this was causing the error).

Fixes giakki/uncss#315